### PR TITLE
feat(inViewport): Debounce event handler to improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ export class AppComponent {
 }
 ```
 
+### Specify debounce time (default: 100ms)
+
+```html
+<p class="foo" inViewport [debounce]="500">
+  Amet tempor excepteur occaecat nulla.
+</p>
+```
+
 [travis-badge]: https://travis-ci.org/edoparearyee/angular-inviewport.svg?branch=master
 [travis-badge-url]: https://travis-ci.org/edoparearyee/angular-inviewport
 [coveralls-badge]: https://coveralls.io/repos/github/edoparearyee/angular-inviewport/badge.svg?branch=master

--- a/src/lib/src/in-viewport.directive.ts
+++ b/src/lib/src/in-viewport.directive.ts
@@ -24,7 +24,10 @@ export interface Size {
  *
  * @example
  * ```
- * <p class="foo" inViewport (onInViewportChange)="myEventHandler($event)">
+ * <p
+ *  class="foo"
+ *  inViewport (onInViewportChange)="myEventHandler($event)"
+ *  [debounce]="300">
  *  Amet tempor excepteur occaecat nulla.
  * </p>
  * ```
@@ -72,7 +75,7 @@ export class InViewportDirective implements OnInit, OnDestroy {
    * before running event handler
    *
    * @type {number}
-   * @default {100}
+   * @default 100
    * @memberof InViewportDirective
    */
   @Input()

--- a/src/lib/src/in-viewport.directive.ts
+++ b/src/lib/src/in-viewport.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener, HostBinding, EventEmitter, Input, Output, OnDestroy } from '@angular/core';
+import { Directive, ElementRef, HostListener, HostBinding, EventEmitter, Input, Output, OnInit, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/takeUntil';
@@ -11,7 +11,7 @@ const eventScroll = 'window:scroll';
 const inViewportClass = 'class.in-viewport';
 const notInViewportClass = 'class.not-in-viewport';
 
-interface Size {
+export interface Size {
   height: number;
   width: number;
 }
@@ -35,7 +35,7 @@ interface Size {
 @Directive({
   selector: '[inViewport]'
 })
-export class InViewportDirective implements OnDestroy {
+export class InViewportDirective implements OnInit, OnDestroy {
   /**
    * If true means the element is in the browser viewport
    *
@@ -104,7 +104,14 @@ export class InViewportDirective implements OnDestroy {
    * @param {ElementRef} el
    * @memberof InViewportDirective
    */
-  constructor(private el: ElementRef) {
+  constructor(private el: ElementRef) { }
+  /**
+   * Subscribe to `viewportSize$` observable which
+   * will call event handler
+   *
+   * @memberof InViewportDirective
+   */
+  public ngOnInit(): void {
     this.viewportSize$
       .takeUntil(this.ngUnsubscribe$)
       .debounceTime(this.debounce)
@@ -132,7 +139,7 @@ export class InViewportDirective implements OnDestroy {
    * @param {Size} size
    * @memberof InViewportDirective
    */
-  private calculateInViewportStatus(size: Size): void {
+  public calculateInViewportStatus(size: Size): void {
     const el: HTMLElement = this.el.nativeElement;
     const bounds = el.getBoundingClientRect();
     const oldInViewport = this.inViewport;


### PR DESCRIPTION
Set by default to 100 but can be configured using attribute binding e.g.:

```html
<p class="foo" inViewport [debounce]="500">
  Amet tempor excepteur occaecat nulla.
</p>
```